### PR TITLE
Fix None Content Issue in Databricks Integration

### DIFF
--- a/src/databricks_ai_bridge/__init__.py
+++ b/src/databricks_ai_bridge/__init__.py
@@ -1,3 +1,13 @@
 from .model_serving_obo_credential_strategy import ModelServingUserCredentials
+from .utils.message_sanitizer import (
+    sanitize_messages_for_databricks,
+    sanitize_input_for_databricks,
+    make_sanitizer_runnable,
+)
 
-__all__ = ["ModelServingUserCredentials"]
+__all__ = [
+    "ModelServingUserCredentials",
+    "sanitize_messages_for_databricks",
+    "sanitize_input_for_databricks",
+    "make_sanitizer_runnable",
+]

--- a/src/databricks_ai_bridge/utils/message_sanitizer.py
+++ b/src/databricks_ai_bridge/utils/message_sanitizer.py
@@ -1,0 +1,90 @@
+from typing import Any, Iterable, List
+
+
+def _coerce_content_empty(message: Any) -> Any:
+    # Prefer pydantic's model_copy if available (LangChain BaseMessage types)
+    try:
+        if hasattr(message, "model_copy"):
+            return message.model_copy(update={"content": ""})
+    except Exception:
+        pass
+    # Fallback: set attribute in place
+    try:
+        if getattr(message, "content", None) is None:
+            setattr(message, "content", "")
+            return message
+    except Exception:
+        pass
+    # Dict-style message
+    if isinstance(message, dict):
+        new_msg = dict(message)
+        if new_msg.get("content", None) is None:
+            new_msg["content"] = ""
+        return new_msg
+    return message
+
+
+def sanitize_messages_for_databricks(messages: Iterable[Any]) -> List[Any]:
+    """
+    Sanitize a sequence of messages before sending to Databricks chat endpoints with input guardrails.
+
+    - Drops assistant messages that contain tool_calls (these serialize with content=null).
+    - Coerces any message with content=None to content="".
+    """
+    sanitized: List[Any] = []
+    for m in messages:
+        # Drop assistant tool-call messages (identified by presence of 'tool_calls' attribute)
+        tool_calls = getattr(m, "tool_calls", None)
+        if tool_calls:
+            # Keep ToolMessages; they do not have 'tool_calls'
+            continue
+
+        content = getattr(m, "content", None)
+        if isinstance(m, dict):
+            content = m.get("content", content)
+
+        if content is None:
+            m = _coerce_content_empty(m)
+
+        sanitized.append(m)
+    return sanitized
+
+
+def sanitize_input_for_databricks(input_obj: Any) -> Any:
+    """
+    Accepts ChatPromptValue, list of messages, or {'messages': [...]}.
+    Returns a list of sanitized messages suitable for model invocation.
+    """
+    # ChatPromptValue-like
+    if hasattr(input_obj, "to_messages"):
+        messages = input_obj.to_messages()
+        return sanitize_messages_for_databricks(messages)
+
+    # Dict-style state with messages
+    if isinstance(input_obj, dict) and "messages" in input_obj:
+        return sanitize_messages_for_databricks(input_obj["messages"])
+
+    # Already a list of messages
+    if isinstance(input_obj, list):
+        return sanitize_messages_for_databricks(input_obj)
+
+    # Unknown input type; return as-is
+    return input_obj
+
+
+def make_sanitizer_runnable():
+    """
+    Returns a RunnableLambda that can be inserted between a prompt and the model:
+      date_assistant_runnable = date_assistant_prompt | make_sanitizer_runnable() | llm.bind_tools([...])
+
+    This requires langchain-core to be installed.
+    """
+    try:
+        from langchain_core.runnables import RunnableLambda
+    except Exception as e:
+        raise ImportError(
+            "langchain-core is required to create a Runnable sanitizer. "
+            "Install langchain-core or import and use sanitize_input_for_databricks directly."
+        ) from e
+
+    return RunnableLambda(sanitize_input_for_databricks)


### PR DESCRIPTION
This pull request adds a sanitizer utility to ensure that messages passed to Databricks do not have None content, which causes errors when input guardrails are enabled. 

The new utility functions, defined in `message_sanitizer.py`, will:
- Coerce any message with content set to None to an empty string.
- Sanitize a list of messages to drop tool call messages from the assistant which contain None content.

These changes solve the issue where empty responses from the assistant lead to input errors by ensuring that all messages passed are valid strings or lists of strings. The main areas of modification are in `src/databricks_ai_bridge/__init__.py` and the newly created `src/databricks_ai_bridge/utils/message_sanitizer.py`.

---

> This pull request was co-created with Cosine Genie

Original Task: [databricks-ai-bridge/bvznvomlg39n](https://cosine.sh/cosinedemo/databricks-ai-bridge/task/bvznvomlg39n)
Author: Pandelis Zembashis
