### PR TITLE
Fix message chunk merging for LLM streaming

### DIFF
--- a/integrations/langchain/src/databricks_langchain/chat_models.py
+++ b/integrations/langchain/src/databricks_langchain/chat_models.py
@@ -407,6 +407,7 @@ class ChatDatabricks(BaseChatModel):
                                 "text": content.text,
                                 "annotations": annotations,
                                 "id": getattr(content, "id", None),
+                                "index": 1,
                             }
                         )
                     elif content.type == "refusal":
@@ -415,6 +416,7 @@ class ChatDatabricks(BaseChatModel):
                                 "type": "refusal",
                                 "refusal": content.refusal,
                                 "id": getattr(content, "id", None),
+                                "index": 1,
                             }
                         )
             elif item.type == "function_call":
@@ -473,9 +475,12 @@ class ChatDatabricks(BaseChatModel):
             ):
                 # For these special types, convert to dict if possible
                 if hasattr(item, "model_dump"):
-                    content_blocks.append(item.model_dump())
+                    block = item.model_dump()
                 else:
-                    content_blocks.append(item)
+                    block = item
+                if isinstance(block, dict) and block.get("type") == "reasoning":
+                    block["index"] = 0
+                content_blocks.append(block)
 
         # Create AI message with combined content and tool calls
         message = AIMessage(
@@ -1250,6 +1255,7 @@ def _convert_responses_api_chunk_to_lc_chunk(
             {
                 "type": "text",
                 "text": chunk.delta,
+                "index": 1,
             }
         )
     elif chunk.type == "response.output_item.done":
@@ -1285,7 +1291,7 @@ def _convert_responses_api_chunk_to_lc_chunk(
                                 ann.model_dump() if hasattr(ann, "model_dump") else ann
                                 for ann in content_item.annotations
                             ]
-                            content.append({"annotations": annotations})
+                            content.append({"annotations": annotations, "index": 1})
                     else:
                         annotations = []
                         if content_item.annotations:
@@ -1300,6 +1306,7 @@ def _convert_responses_api_chunk_to_lc_chunk(
                                 "type": "text",
                                 "text": content_item.text,
                                 "annotations": annotations,
+                                "index": 1,
                             }
                         )
                 elif content_item.type == "refusal":
@@ -1307,6 +1314,7 @@ def _convert_responses_api_chunk_to_lc_chunk(
                         {
                             "type": "refusal",
                             "refusal": content_item.refusal,
+                            "index": 1,
                         }
                     )
         elif item.type in (
@@ -1322,9 +1330,12 @@ def _convert_responses_api_chunk_to_lc_chunk(
         ):
             # Convert item to dictionary for LangChain compatibility
             if hasattr(item, "model_dump"):
-                content.append(item.model_dump())
+                block = item.model_dump()
             else:
-                content.append(item)
+                block = item
+            if isinstance(block, dict) and block.get("type") == "reasoning":
+                block["index"] = 0
+            content.append(block)
     elif chunk.type == "response.created":
         id = chunk.response.id if chunk.response else None
         return AIMessageChunk(content="", id=id)

--- a/integrations/langchain/tests/unit_tests/test_chat_models.py
+++ b/integrations/langchain/tests/unit_tests/test_chat_models.py
@@ -748,7 +748,10 @@ def test_convert_responses_api_chunk_to_lc_chunk_text_delta():
     result = _convert_responses_api_chunk_to_lc_chunk(chunk)
 
     assert isinstance(result, AIMessageChunk)
-    assert result.content == [{"type": "text", "text": "Hello"}]
+    assert isinstance(result.content, list) and len(result.content) == 1
+    assert result.content[0]["type"] == "text"
+    assert result.content[0]["text"] == "Hello"
+    assert result.content[0]["index"] == 1
     assert result.id == "item_123"
 
 
@@ -1083,12 +1086,18 @@ def test_chat_databricks_responses_api_stream():
 
         # Check first chunk
         assert isinstance(chunks[0], AIMessageChunk)
-        assert chunks[0].content == [{"type": "text", "text": "Hello"}]
+        assert isinstance(chunks[0].content, list) and len(chunks[0].content) == 1
+        assert chunks[0].content[0]["type"] == "text"
+        assert chunks[0].content[0]["text"] == "Hello"
+        assert chunks[0].content[0]["index"] == 1
         assert chunks[0].id == "item_123"
 
         # Check second chunk
         assert isinstance(chunks[1], AIMessageChunk)
-        assert chunks[1].content == [{"type": "text", "text": " world"}]
+        assert isinstance(chunks[1].content, list) and len(chunks[1].content) == 1
+        assert chunks[1].content[0]["type"] == "text"
+        assert chunks[1].content[0]["text"] == " world"
+        assert chunks[1].content[0]["index"] == 1
         assert chunks[1].id == "item_123"
 
 


### PR DESCRIPTION
This PR addresses the issue with merging message chunks during streaming using the `llm.stream` method. In the `_convert_responses_api_response_to_chat_result` function, I have added an `index` field to chunk messages. Specifically, reasoning chunks now have `index: 0` and text chunks have `index: 1`, allowing the `merge_chat_generation_chunks` function to work as intended by properly organizing the content. Additionally, unit tests have been updated to reflect these changes and ensure they validate the updated structure. This ensures that messages are merged correctly without losing context.

---

> This pull request was co-created with Cosine Genie

Original Task: [databricks-ai-bridge/a8mfk3uoz06x](https://cosine.sh/cosinedemo/databricks-ai-bridge/task/a8mfk3uoz06x)
Author: Pandelis Zembashis
